### PR TITLE
chore(feat): add middleware decorator and change validator trait

### DIFF
--- a/src/App/Decorator/Middleware.ts
+++ b/src/App/Decorator/Middleware.ts
@@ -38,3 +38,11 @@ export function validator<T extends {}>(method: keyof ValidationTargets, data: Z
         reflectingMetadata(targetFunc, funcValidator);
     };
 }
+
+export function middleware(handler: MiddlewareHandler | Promise<MiddlewareHandler> | Promise<void>): Function {
+    return function decorate(target: Controller, propKey: string, descriptor: PropertyDescriptor): void {
+        const targetFunc = descriptor.value as Function;
+        const targetHandler = handler as MiddlewareHandler;
+        reflectingMetadata(targetFunc, targetHandler);
+    };
+}

--- a/src/App/Decorator/Middleware.ts
+++ b/src/App/Decorator/Middleware.ts
@@ -39,6 +39,12 @@ export function validator<T extends {}>(method: keyof ValidationTargets, data: Z
     };
 }
 
+/**
+ * Add middleware on route.
+ *
+ * @param handlers - Middleware handlers for route
+ * @see MiddlewareHandler
+ */
 export function middleware(...handlers: MiddlewareHandler[] | Promise<MiddlewareHandler>[] | Promise<void>[]): Function {
     return function decorate(target: Controller, propKey: string, descriptor: PropertyDescriptor): void {
         const targetFunc = descriptor.value as Function;

--- a/src/App/Decorator/Middleware.ts
+++ b/src/App/Decorator/Middleware.ts
@@ -39,10 +39,12 @@ export function validator<T extends {}>(method: keyof ValidationTargets, data: Z
     };
 }
 
-export function middleware(handler: MiddlewareHandler | Promise<MiddlewareHandler> | Promise<void>): Function {
+export function middleware(...handlers: MiddlewareHandler[] | Promise<MiddlewareHandler>[] | Promise<void>[]): Function {
     return function decorate(target: Controller, propKey: string, descriptor: PropertyDescriptor): void {
         const targetFunc = descriptor.value as Function;
-        const targetHandler = handler as MiddlewareHandler;
-        reflectingMetadata(targetFunc, targetHandler);
+        for (const handler of handlers) {
+            const targetHandler = handler as MiddlewareHandler;
+            reflectingMetadata(targetFunc, targetHandler);
+        }
     };
 }

--- a/src/App/Types/ControllerConstant.ts
+++ b/src/App/Types/ControllerConstant.ts
@@ -1,2 +1,2 @@
 export const MetadataConstant = "agniRouting";
-export const MetadataValidatorConstant = "agniValidator";
+export const MetadataMiddlewareConstant = "agniMiddleware";

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -49,9 +49,8 @@ export default class Controller {
             }
 
             ctx.push(func);
-            Logger.info(`Register ${metadata.method}:${metadata.path} route`);
+            Logger.info(`Register ${metadata.method}:${metadata.path} route [${ctx.length} handler]`);
 
-            // TODO [2024-03-01]: How to bypass this?
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-expect-error
             const handlers = this._honoFactory.createHandlers(...ctx);

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -3,7 +3,7 @@ import type { Factory } from "hono/factory";
 import { createFactory } from "hono/factory";
 import type { HandlerInterface, MiddlewareHandler } from "hono/types";
 import { InsufficientControllerMethodError, NotSupportedMethodError } from "App/Error/AppError.js";
-import { MetadataConstant, MetadataValidatorConstant } from "App/Types/ControllerConstant.js";
+import { MetadataConstant, MetadataMiddlewareConstant } from "App/Types/ControllerConstant.js";
 import type {
     AgniRoutingMetadata,
     AgniSupportedMethod,
@@ -40,13 +40,12 @@ export default class Controller {
                 throw new NotSupportedMethodError();
             }
 
-            /**
-             * TODO [2024-02-27]: Add support for middleware, multi handler/middleware
-             */
             const ctx: DefaultHonoFunctionContext[] = [];
-            if (metadataKeys.includes(MetadataValidatorConstant)) {
-                const middleware = Reflect.getMetadata(MetadataValidatorConstant, func) as MiddlewareHandler;
-                ctx.push(this._honoFactory.createMiddleware(middleware));
+            if (metadataKeys.includes(MetadataMiddlewareConstant)) {
+                const middleware = Reflect.getMetadata(MetadataMiddlewareConstant, func) as MiddlewareHandler[];
+                for (const midFunc of middleware) {
+                    ctx.push(this._honoFactory.createMiddleware(midFunc));
+                }
             }
 
             ctx.push(func);

--- a/src/Controller/HelloController.ts
+++ b/src/Controller/HelloController.ts
@@ -1,15 +1,28 @@
+import type { Next } from "hono";
+import { cors } from "hono/cors";
 import { z } from "zod";
 import httpRoute from "App/Decorator/HttpRoute.js";
-import { validator } from "App/Decorator/Middleware.js";
+import { middleware, validator } from "App/Decorator/Middleware.js";
 import type { DefaultHonoContext, HonoInputContext } from "App/Types/ControllerTypes.js";
+import Logger from "Logger.js";
 import Controller from "./Controller.js";
 
 type HelloValidator = {
     message: string;
 };
 
+// Since we cannot calling this keyword on decorator,
+// you must create some function outside the class or make some new function file.
+async function indexMiddleware(_: DefaultHonoContext, next: Next): Promise<void> {
+    Logger.info("You're accessing index!");
+    await next();
+    Logger.info("Done!");
+}
+
 export default class HelloController extends Controller {
     @httpRoute("get", "/")
+    @middleware(cors())
+    @middleware(indexMiddleware)
     public hellow(c: DefaultHonoContext): Response {
         return c.text("Say hello world!");
     }

--- a/src/Controller/HelloController.ts
+++ b/src/Controller/HelloController.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import httpRoute from "App/Decorator/HttpRoute.js";
-import validator from "App/Decorator/Validator.js";
+import { validator } from "App/Decorator/Middleware.js";
 import type { DefaultHonoContext, HonoInputContext } from "App/Types/ControllerTypes.js";
 import Controller from "./Controller.js";
 

--- a/src/Controller/HelloController.ts
+++ b/src/Controller/HelloController.ts
@@ -21,8 +21,7 @@ async function indexMiddleware(_: DefaultHonoContext, next: Next): Promise<void>
 
 export default class HelloController extends Controller {
     @httpRoute("get", "/")
-    @middleware(cors())
-    @middleware(indexMiddleware)
+    @middleware(cors(), indexMiddleware)
     public hellow(c: DefaultHonoContext): Response {
         return c.text("Say hello world!");
     }

--- a/src/Function/OnValidateError.ts
+++ b/src/Function/OnValidateError.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import type { ZodData } from "App/Decorator/Validator.js";
+import type { ZodData } from "App/Decorator/Middleware.js";
 import isJson from "App/Function/IsJson.js";
 
 export function onValidateError(c: Context<any, any, any>, data: ZodData<any>): Response {


### PR DESCRIPTION
- Changing Validator trait as Middleware because it's the same behind the scenes.
- Casting all `Promise<void>` as MiddlewareHandler on Reflect because it is using the same traits as MiddlewareHandler. The function that using return `Promise<void>` on handler is for middleware that have `next` keyword.
- Implementing and giving example how to use the decorator on HelloController.